### PR TITLE
Remove underscore syntax from Asm because of undefined behavior + misc formatting

### DIFF
--- a/tests/0_test_style_guide.txt
+++ b/tests/0_test_style_guide.txt
@@ -19,7 +19,7 @@ Each distinct test case should have its own function named "test_[op mnemonic]_[
 Not formalized as of now, go for best effort emulation of existing files. See e.g. "test_and.rs". 
 
     - Number formatting:
-Constants should normally be written in hexadecimal, with an even number of characters (e.g. 0x01 and 0x0100, not 0x1 and 0x100), and in Rust sections an underscore should separate every 4 characters (0x1234_5678). A very important note here is that while it's possible in some cases to use underscores to format Assembly constants this is an unintended behavior and shouldn't be used. 
+Constants should normally be written in upper-case hexadecimal, with an even number of characters (e.g. 0x01 and 0x0100, not 0x1 and 0x100), and in Rust sections an underscore should separate every 4 characters (0x1234_5678). A very important note here is that while it's possible in some cases to use underscores to format Assembly constants this is an unintended behavior and shouldn't be used. 
 
     - General Rust code style: 
 The code should be formatted using the built-in "rustfmt" command (run "rustfmt *.rs" in this directory). At some point configurations should probably be made, but for now default is acceptable. 

--- a/tests/0_test_style_guide.txt
+++ b/tests/0_test_style_guide.txt
@@ -1,0 +1,22 @@
+###########################################################
+### Unofficial style guide for NarmVM opcode unit tests ###
+###########################################################
+
+NOTE: This is an incomplete WIP document created mostly to record formatting decisions made as development goes. Changes and additions are allowed and welcome, as long as all files are modified to comply. 
+
+
+
+    - Files:          
+There should be one file per opcode, named "test_[base op mnemonic].rs". When it makes sense exceptions are allowed for "variant" opcodes, e.g. add with and without -s suffix, or "pseudo ops", distinct assembly mnemonics that compile to a special case of a base opcode. 
+
+    - Directory structure: 
+Not formalized as of now, but at some point it will probably be needed for easy overview. 
+
+    - Functions: 
+Each distinct test case should have its own function named "test_[op mnemonic]_[case shorthand]". If the same/very similar case is tested for several opcodes it's much preferred to use the same case shorthand for easy overview. 
+
+    - Code structure:       
+Not formalized as of now, go for best effort emulation of existing files. See e.g. "test_and.rs". 
+
+    - Number formatting:
+Constants should normally be written in hexadecimal, with an even number of characters (e.g. 0x01 and 0x0100, not 0x1 and 0x100), and in Rust sections an underscore should separate every 4 characters (0x1234_5678). A very important note here is that while it's possible in some cases to use underscores to format Assembly constants this is an unintended behavior and shouldn't be used. 

--- a/tests/0_test_style_guide.txt
+++ b/tests/0_test_style_guide.txt
@@ -20,3 +20,6 @@ Not formalized as of now, go for best effort emulation of existing files. See e.
 
     - Number formatting:
 Constants should normally be written in hexadecimal, with an even number of characters (e.g. 0x01 and 0x0100, not 0x1 and 0x100), and in Rust sections an underscore should separate every 4 characters (0x1234_5678). A very important note here is that while it's possible in some cases to use underscores to format Assembly constants this is an unintended behavior and shouldn't be used. 
+
+    - General Rust code style: 
+The code should be formatted using the built-in "rustfmt" command (run "rustfmt *.rs" in this directory). At some point configurations should probably be made, but for now default is acceptable. 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,13 +9,13 @@ pub fn create_vm_from_asm(assembly_code: &str) -> NarmVM {
     let file = asm(assembly_code);
 
     let text_scn = file.get_section(".text").unwrap();
-    assert!(text_scn.shdr.addr == 0x1_0000);
-    assert!(text_scn.data.len() < 0x1_0000);
+    assert!(text_scn.shdr.addr == 0x01_0000);
+    assert!(text_scn.data.len() < 0x01_0000);
 
     let mut vm = NarmVM::default();
-    vm.memory.add_memory(0x1_0000, 0x1_0000).unwrap();
-    vm.copy_into_memory(0x1_0000, &text_scn.data).unwrap();
-    vm.set_pc(0x1_0000);
+    vm.memory.add_memory(0x01_0000, 0x01_0000).unwrap();
+    vm.copy_into_memory(0x01_0000, &text_scn.data).unwrap();
+    vm.set_pc(0x01_0000);
     vm.gas_remaining = DEFAULT_GAS;
     vm
 }
@@ -41,7 +41,7 @@ pub fn asm(input: &str) -> elf::File {
     ENTRY (_start)
     SECTIONS
     {
-        . = 0x10000;
+        . = 0x010000;
         .text : { *(.text*) *(.rodata*) }
         .data : { *(.data*) }
         /*.bss : { *(.bss*) *(COMMON*) }*/
@@ -115,7 +115,7 @@ Basic test format:
 
     let mut vm_expected: VMState = Default::default(); <- Default is check all, 0 for regs and false (ie unset/0) for flags
 
-    vm_expected.r[0] = Some(0x00_00_00_AF); <- r0 should be this value
+    vm_expected.r[0] = Some(0xAF); <- r0 should be this value
     vm_expected.c = Some(true);             <- Carry flag should be true (ie set/1)
     vm_expected.r[1] = None;                <- r1 won't be checked, any value will pass the test
 
@@ -162,18 +162,18 @@ impl Default for VMState {
     }
 }
 
-// Format u32 to hex string approperiatly padded with zeroes
-// TODO: Capital letters?
-// TODO: Underscores separating bytes?
+// Format u32 to hex string approperiatly padded with zeroes for easy side-by-side comparison
+// TODO: Underscores?
 pub fn format_padded_hex(int: u32) -> String {
     let mut string = String::from(format!("{:x}", int));
     while string.len() < 8 {
         string = format!("0{}", string)
     }
-    string
+    string.to_uppercase()
 }
 
 // Macro to assert values in VMState struct against the actual VM's state
+// Includes a custom error message that formats register values to padded hex strings in addition to the default decimal print
 // This could be done as a function, but that would bloat a stack trace compared to an inlined macro.
 #[macro_export]
 macro_rules! assert_vm_eq {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,11 +2,10 @@ extern crate elf;
 
 use narm::narmvm::*;
 
-
-const DEFAULT_GAS:u64 = 10000;
+const DEFAULT_GAS: u64 = 10000;
 
 #[cfg(test)]
-pub fn create_vm_from_asm(assembly_code: &str) -> NarmVM{
+pub fn create_vm_from_asm(assembly_code: &str) -> NarmVM {
     let file = asm(assembly_code);
 
     let text_scn = file.get_section(".text").unwrap();
@@ -22,18 +21,22 @@ pub fn create_vm_from_asm(assembly_code: &str) -> NarmVM{
 }
 
 #[cfg(test)]
-pub fn asm(input: &str) -> elf::File{
-    use tempfile::*;
+pub fn asm(input: &str) -> elf::File {
     use std::io::Write;
     use std::process::Command;
-    let asm = format!("{}{}", "
+    use tempfile::*;
+    let asm = format!(
+        "{}{}",
+        "
     .syntax unified
     .section .text
     .thumb_func
     .globl _start
     _start:
 
-    ", input);
+    ",
+        input
+    );
     let linkerscript = "
     ENTRY (_start)
     SECTIONS
@@ -52,39 +55,50 @@ pub fn asm(input: &str) -> elf::File{
     println!("asm: {}\n---------------", asm);
 
     let mut f1 = std::fs::File::create(&input).unwrap();
-    writeln!(f1,"{}", asm).unwrap();
+    writeln!(f1, "{}", asm).unwrap();
     f1.flush().unwrap();
 
-
     let mut f2 = std::fs::File::create(&linkfile).unwrap();
-    writeln!(f2,"{}", linkerscript).unwrap();
+    writeln!(f2, "{}", linkerscript).unwrap();
     f2.flush().unwrap();
 
     // The following commands will be executed
     // arm-none-eabi-as -march=armv6s-m -o$OBJECT $INPUT
     // arm-none-eabi-ld -T link.ld -o$OUTPUT $OBJECTF
-    
-    let result = Command::new("arm-none-eabi-as").
-        arg("-march=armv6s-m").
-        arg(format!("{}{}", "-o", &object.to_str().unwrap())).
-        arg(&input).
-        output().unwrap();
-    println!("as stdout: {}", std::str::from_utf8(&result.stdout).unwrap());
-    println!("as stderr: {}", std::str::from_utf8(&result.stderr).unwrap());
 
-    let result = Command::new("arm-none-eabi-ld").
-        arg(format!("{}{}", "-T", &linkfile.to_str().unwrap())).
-        arg(format!("{}{}", "-o", &output.to_str().unwrap())).
-        arg(&object).
-        output().unwrap();
+    let result = Command::new("arm-none-eabi-as")
+        .arg("-march=armv6s-m")
+        .arg(format!("{}{}", "-o", &object.to_str().unwrap()))
+        .arg(&input)
+        .output()
+        .unwrap();
+    println!(
+        "as stdout: {}",
+        std::str::from_utf8(&result.stdout).unwrap()
+    );
+    println!(
+        "as stderr: {}",
+        std::str::from_utf8(&result.stderr).unwrap()
+    );
 
-    println!("ld stdout: {}", std::str::from_utf8(&result.stdout).unwrap());
-    println!("ld stderr: {}", std::str::from_utf8(&result.stderr).unwrap());
+    let result = Command::new("arm-none-eabi-ld")
+        .arg(format!("{}{}", "-T", &linkfile.to_str().unwrap()))
+        .arg(format!("{}{}", "-o", &output.to_str().unwrap()))
+        .arg(&object)
+        .output()
+        .unwrap();
+
+    println!(
+        "ld stdout: {}",
+        std::str::from_utf8(&result.stdout).unwrap()
+    );
+    println!(
+        "ld stderr: {}",
+        std::str::from_utf8(&result.stderr).unwrap()
+    );
 
     elf::File::open_path(output).unwrap()
 }
-
-
 
 /*
 
@@ -93,33 +107,31 @@ pub fn asm(input: &str) -> elf::File{
 The VMState structure contains expected values for each registry and flag exposed by the VM
 By default everything is checked and expected to be 0/false, but tests can be altered or turned off individually
 
-Basic test format: 
+Basic test format:
 
-    let mut vm = ... 
-    
+    let mut vm = ...
+
     ...
-    
+
     let mut vm_expected: VMState = Default::default(); <- Default is check all, 0 for regs and false (ie unset/0) for flags
-    
+
     vm_expected.r[0] = Some(0x00_00_00_AF); <- r0 should be this value
     vm_expected.c = Some(true);             <- Carry flag should be true (ie set/1)
     vm_expected.r[1] = None;                <- r1 won't be checked, any value will pass the test
-    
+
     assert_vm_eq!(vm_expected, vm);         <- Actually do the asserts
 
 */
-
-
 
 // TODO: Handle special registers differently?
 // TODO: Implement memory area assertion? Maybe too advanced?
 #[allow(dead_code)]
 pub struct VMState {
-    pub r:  [Option<u32>; 15], // Exclude PC for the time being
-    pub n:  Option<bool>,
-    pub z:  Option<bool>,
-    pub c:  Option<bool>,
-    pub v:  Option<bool>,
+    pub r: [Option<u32>; 15], // Exclude PC for the time being
+    pub n: Option<bool>,
+    pub z: Option<bool>,
+    pub c: Option<bool>,
+    pub v: Option<bool>,
 }
 
 impl Default for VMState {
@@ -140,20 +152,20 @@ impl Default for VMState {
                 Some(0), // r11
                 Some(0), // r12
                 Some(0), // r13
-                Some(0),  // r14
-            ], 
-            n:  Some(false),
-            z:  Some(false),
-            c:  Some(false),
-            v:  Some(false),
+                Some(0), // r14
+            ],
+            n: Some(false),
+            z: Some(false),
+            c: Some(false),
+            v: Some(false),
         }
     }
 }
 
-// Format u32 to hex string approperiatly padded with zeroes 
+// Format u32 to hex string approperiatly padded with zeroes
 // TODO: Capital letters?
 // TODO: Underscores separating bytes?
-pub fn format_padded_hex(int: u32) -> String{
+pub fn format_padded_hex(int: u32) -> String {
     let mut string = String::from(format!("{:x}", int));
     while string.len() < 8 {
         string = format!("0{}", string)
@@ -162,7 +174,7 @@ pub fn format_padded_hex(int: u32) -> String{
 }
 
 // Macro to assert values in VMState struct against the actual VM's state
-// This could be done as a function, but that would bloat a stack trace compared to an inlined macro. 
+// This could be done as a function, but that would bloat a stack trace compared to an inlined macro.
 #[macro_export]
 macro_rules! assert_vm_eq {
     ( $vmstate:ident, $vm:ident ) => {

--- a/tests/test_and.rs
+++ b/tests/test_and.rs
@@ -25,17 +25,17 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_and_register(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x0000000F
-        movs r1,            #0x000000AA
+        movs r0,            #0x0F
+        movs r1,            #0xAA
         ands r0, r1
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_000A);
-    vm_expected.r[1] = Some(0x0000_00AA);
+    vm_expected.r[0] = Some(0x0A);
+    vm_expected.r[1] = Some(0xAA);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -44,17 +44,17 @@ pub fn test_and_register(){
 #[test]
 pub fn test_and_flag_zero(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x00000055
-        movs r1,            #0x000000AA
+        movs r0,            #0x55
+        movs r1,            #0xAA
         ands r0, r1
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_0000);
-    vm_expected.r[1] = Some(0x0000_00AA);
+    vm_expected.r[0] = Some(0x00);
+    vm_expected.r[1] = Some(0xAA);
     vm_expected.z = Some(true);
     
     assert_vm_eq!(vm_expected, vm);
@@ -65,13 +65,13 @@ pub fn test_and_flag_zero(){
 #[test]
 pub fn test_and_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x00000002
-        lsls r0,            #0x0000000F
-        lsls r0,            #0x0000000F
+        movs r0,            #0x02
+        lsls r0,            #0x0F
+        lsls r0,            #0x0F
         ands r0, r0
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     

--- a/tests/test_and.rs
+++ b/tests/test_and.rs
@@ -14,7 +14,6 @@ Included cases:
 - Set Negative flag if result is negative
 
 All tests also check for unexpected changes in registers and condition flags
-TODO: Add tests where untargeted values are pre-set and check if incorrectly reset?
 
 The reference for these tests is currently official documentations and a QEMU-based VM
 TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?

--- a/tests/test_and.rs
+++ b/tests/test_and.rs
@@ -7,7 +7,7 @@ use common::*;
 
 Unit test for bitwise AND operator
 
-Included cases: 
+Included cases:
 
 - Calculate correctly for two register values
 - Set Zero flag if result is zero
@@ -23,60 +23,66 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 
 // Test if operation calculate correctly for two register values
 #[test]
-pub fn test_and_register(){
-    let mut vm = create_vm_from_asm("
+pub fn test_and_register() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x0F
         movs r1,            #0xAA
         ands r0, r1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0x0A);
     vm_expected.r[1] = Some(0xAA);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 // Test if operation set Zero flag if result is zero
 #[test]
-pub fn test_and_flag_zero(){
-    let mut vm = create_vm_from_asm("
+pub fn test_and_flag_zero() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x55
         movs r1,            #0xAA
         ands r0, r1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0x00);
     vm_expected.r[1] = Some(0xAA);
     vm_expected.z = Some(true);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 // Test if operation set Negative flag if result is negative
 // (Most significant bit indicate sign in 2-complement int representation, so setting it to 1 -> negative number)
 #[test]
-pub fn test_and_flag_neg(){
-    let mut vm = create_vm_from_asm("
+pub fn test_and_flag_neg() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x02
         lsls r0,            #0x0F
         lsls r0,            #0x0F
         ands r0, r0
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0x8000_0000);
     vm_expected.n = Some(true);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }

--- a/tests/test_and.rs
+++ b/tests/test_and.rs
@@ -25,10 +25,10 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_and_register(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x0000000F
-        movs r1, #0x000000AA
+        movs r0,            #0x0000000F
+        movs r1,            #0x000000AA
         ands r0, r1
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
@@ -44,10 +44,10 @@ pub fn test_and_register(){
 #[test]
 pub fn test_and_flag_zero(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00000055
-        movs r1, #0x000000AA
+        movs r0,            #0x00000055
+        movs r1,            #0x000000AA
         ands r0, r1
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
@@ -65,11 +65,11 @@ pub fn test_and_flag_zero(){
 #[test]
 pub fn test_and_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00000002
-        lsls r0, #0x0000000F
-        lsls r0, #0x0000000F
+        movs r0,            #0x00000002
+        lsls r0,            #0x0000000F
+        lsls r0,            #0x0000000F
         ands r0, r0
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();

--- a/tests/test_and.rs
+++ b/tests/test_and.rs
@@ -13,7 +13,7 @@ Included cases:
 - Set Zero flag if result is zero
 - Set Negative flag if result is negative
 
-All tests also check for unexpected changes in untargeted lo registers and condition flags
+All tests also check for unexpected changes in registers and condition flags
 TODO: Add tests where untargeted values are pre-set and check if incorrectly reset?
 
 The reference for these tests is currently official documentations and a QEMU-based VM
@@ -21,7 +21,7 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 
 */
 
-// Test if AND(... 0000 1111, ... 1010 1010) = ... 0000 1010
+// Test if operation calculate correctly for two register values
 #[test]
 pub fn test_and_register(){
     let mut vm = create_vm_from_asm("
@@ -40,7 +40,7 @@ pub fn test_and_register(){
     assert_vm_eq!(vm_expected, vm);
 }
 
-// Test if AND(... 0101 0101, ... 1010 1010) correctly sets Zero flag
+// Test if operation set Zero flag if result is zero
 #[test]
 pub fn test_and_flag_zero(){
     let mut vm = create_vm_from_asm("
@@ -60,7 +60,7 @@ pub fn test_and_flag_zero(){
     assert_vm_eq!(vm_expected, vm);
 }
 
-// Test if AND(1000 ... 0000, 1000 ... 0000) correctly sets Negative flag
+// Test if operation set Negative flag if result is negative
 // (Most significant bit indicate sign in 2-complement int representation, so setting it to 1 -> negative number)
 #[test]
 pub fn test_and_flag_neg(){

--- a/tests/test_and.rs
+++ b/tests/test_and.rs
@@ -25,17 +25,17 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_and_register(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_0F
-        movs r1, #0x00_00_00_AA
+        movs r0, #0x0000000F
+        movs r1, #0x000000AA
         ands r0, r1
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_0A);
-    vm_expected.r[1] = Some(0x00_00_00_AA);
+    vm_expected.r[0] = Some(0x0000_000A);
+    vm_expected.r[1] = Some(0x0000_00AA);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -44,17 +44,17 @@ pub fn test_and_register(){
 #[test]
 pub fn test_and_flag_zero(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_55
-        movs r1, #0x00_00_00_AA
+        movs r0, #0x00000055
+        movs r1, #0x000000AA
         ands r0, r1
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_00);
-    vm_expected.r[1] = Some(0x00_00_00_AA);
+    vm_expected.r[0] = Some(0x0000_0000);
+    vm_expected.r[1] = Some(0x0000_00AA);
     vm_expected.z = Some(true);
     
     assert_vm_eq!(vm_expected, vm);
@@ -65,17 +65,17 @@ pub fn test_and_flag_zero(){
 #[test]
 pub fn test_and_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_02
-        lsls r0, #0x00_00_00_0F
-        lsls r0, #0x00_00_00_0F
+        movs r0, #0x00000002
+        lsls r0, #0x0000000F
+        lsls r0, #0x0000000F
         ands r0, r0
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x80_00_00_00);
+    vm_expected.r[0] = Some(0x8000_0000);
     vm_expected.n = Some(true);
     
     assert_vm_eq!(vm_expected, vm);

--- a/tests/test_cycle.rs
+++ b/tests/test_cycle.rs
@@ -6,31 +6,34 @@ use common::*;
 // this file is for basic smoke testing of the actual common.rs test functions
 
 #[test]
-pub fn test_cycle(){
-    let mut vm = create_vm_from_asm("
+pub fn test_cycle() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0xF1
-    ");
+    ",
+    );
     vm.cycle().unwrap();
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0xF1);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 #[test]
-pub fn test_execute(){
-    let mut vm = create_vm_from_asm("
+pub fn test_execute() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0xF1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0xF1);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
-

--- a/tests/test_cycle.rs
+++ b/tests/test_cycle.rs
@@ -8,13 +8,13 @@ use common::*;
 #[test]
 pub fn test_cycle(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x000000F1
+        movs r0,            #0xF1
     ");
     vm.cycle().unwrap();
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_00F1);
+    vm_expected.r[0] = Some(0xF1);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -22,14 +22,14 @@ pub fn test_cycle(){
 #[test]
 pub fn test_execute(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x000000F1
-        svc                 #0x000000FF
+        movs r0,            #0xF1
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_00F1);
+    vm_expected.r[0] = Some(0xF1);
     
     assert_vm_eq!(vm_expected, vm);
 }

--- a/tests/test_cycle.rs
+++ b/tests/test_cycle.rs
@@ -8,7 +8,7 @@ use common::*;
 #[test]
 pub fn test_cycle(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x000000F1
+        movs r0,            #0x000000F1
     ");
     vm.cycle().unwrap();
     vm.print_diagnostics();
@@ -22,8 +22,8 @@ pub fn test_cycle(){
 #[test]
 pub fn test_execute(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x000000F1
-        svc #0x000000FF
+        movs r0,            #0x000000F1
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();

--- a/tests/test_cycle.rs
+++ b/tests/test_cycle.rs
@@ -8,13 +8,13 @@ use common::*;
 #[test]
 pub fn test_cycle(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_F1
+        movs r0, #0x000000F1
     ");
     vm.cycle().unwrap();
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_F1);
+    vm_expected.r[0] = Some(0x0000_00F1);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -22,14 +22,14 @@ pub fn test_cycle(){
 #[test]
 pub fn test_execute(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_F1
-        svc #0x00_00_00_FF
+        movs r0, #0x000000F1
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_F1);
+    vm_expected.r[0] = Some(0x0000_00F1);
     
     assert_vm_eq!(vm_expected, vm);
 }

--- a/tests/test_orr.rs
+++ b/tests/test_orr.rs
@@ -14,7 +14,6 @@ Included cases:
 - Set Negative flag if result is negative
 
 All tests also check for unexpected changes in registers and condition flags
-TODO: Add tests where untargeted values are pre-set and check if incorrectly reset?
 
 The reference for these tests is currently official documentations and a QEMU-based VM
 TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?

--- a/tests/test_orr.rs
+++ b/tests/test_orr.rs
@@ -7,7 +7,7 @@ use common::*;
 
 Unit test for bitwise OR operator
 
-Included cases: 
+Included cases:
 
 - Calculate correctly for two register values
 - Set Zero flag if result is zero
@@ -23,56 +23,62 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 
 // Test if operation calculate correctly for two register values
 #[test]
-pub fn test_orr_register(){
-    let mut vm = create_vm_from_asm("
+pub fn test_orr_register() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x05
         movs r1,            #0xAA
         orrs r0, r1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0xAF);
     vm_expected.r[1] = Some(0xAA);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 // Test if operation set Zero flag if result is zero
 #[test]
-pub fn test_orr_flag_zero(){
-    let mut vm = create_vm_from_asm("
+pub fn test_orr_flag_zero() {
+    let mut vm = create_vm_from_asm(
+        "
         orrs r0, r1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.z = Some(true);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 // Test if operation set Negative flag if result is negative
 // ("highest" bit indicate sign in int representation, so setting it to 1 -> negative number)
 #[test]
-pub fn test_orr_flag_neg(){
-    let mut vm = create_vm_from_asm("
+pub fn test_orr_flag_neg() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x02
         lsls r0,            #0x0F
         lsls r0,            #0x0F
         orrs r0, r0
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0x8000_0000);
     vm_expected.n = Some(true);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }

--- a/tests/test_orr.rs
+++ b/tests/test_orr.rs
@@ -25,17 +25,17 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_orr_register(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x00000005
-        movs r1,            #0x000000AA
+        movs r0,            #0x05
+        movs r1,            #0xAA
         orrs r0, r1
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_00AF);
-    vm_expected.r[1] = Some(0x0000_00AA);
+    vm_expected.r[0] = Some(0xAF);
+    vm_expected.r[1] = Some(0xAA);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -45,9 +45,9 @@ pub fn test_orr_register(){
 pub fn test_orr_flag_zero(){
     let mut vm = create_vm_from_asm("
         orrs r0, r1
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
@@ -61,13 +61,13 @@ pub fn test_orr_flag_zero(){
 #[test]
 pub fn test_orr_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x00000002
-        lsls r0,            #0x0000000F
-        lsls r0,            #0x0000000F
+        movs r0,            #0x02
+        lsls r0,            #0x0F
+        lsls r0,            #0x0F
         orrs r0, r0
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     

--- a/tests/test_orr.rs
+++ b/tests/test_orr.rs
@@ -25,17 +25,17 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_orr_register(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_05
-        movs r1, #0x00_00_00_AA
+        movs r0, #0x00000005
+        movs r1, #0x000000AA
         orrs r0, r1
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_AF);
-    vm_expected.r[1] = Some(0x00_00_00_AA);
+    vm_expected.r[0] = Some(0x0000_00AF);
+    vm_expected.r[1] = Some(0x0000_00AA);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -45,9 +45,9 @@ pub fn test_orr_register(){
 pub fn test_orr_flag_zero(){
     let mut vm = create_vm_from_asm("
         orrs r0, r1
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
@@ -61,17 +61,17 @@ pub fn test_orr_flag_zero(){
 #[test]
 pub fn test_orr_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_02
-        lsls r0, #0x00_00_00_0F
-        lsls r0, #0x00_00_00_0F
+        movs r0, #0x00000002
+        lsls r0, #0x0000000F
+        lsls r0, #0x0000000F
         orrs r0, r0
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x80_00_00_00);
+    vm_expected.r[0] = Some(0x8000_0000);
     vm_expected.n = Some(true);
     
     assert_vm_eq!(vm_expected, vm);

--- a/tests/test_orr.rs
+++ b/tests/test_orr.rs
@@ -25,10 +25,10 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_orr_register(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00000005
-        movs r1, #0x000000AA
+        movs r0,            #0x00000005
+        movs r1,            #0x000000AA
         orrs r0, r1
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
@@ -45,7 +45,7 @@ pub fn test_orr_register(){
 pub fn test_orr_flag_zero(){
     let mut vm = create_vm_from_asm("
         orrs r0, r1
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
@@ -61,11 +61,11 @@ pub fn test_orr_flag_zero(){
 #[test]
 pub fn test_orr_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00000002
-        lsls r0, #0x0000000F
-        lsls r0, #0x0000000F
+        movs r0,            #0x00000002
+        lsls r0,            #0x0000000F
+        lsls r0,            #0x0000000F
         orrs r0, r0
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();

--- a/tests/test_orr.rs
+++ b/tests/test_orr.rs
@@ -13,7 +13,7 @@ Included cases:
 - Set Zero flag if result is zero
 - Set Negative flag if result is negative
 
-All tests also check for unexpected changes in untargeted lo registers and condition flags
+All tests also check for unexpected changes in registers and condition flags
 TODO: Add tests where untargeted values are pre-set and check if incorrectly reset?
 
 The reference for these tests is currently official documentations and a QEMU-based VM
@@ -21,7 +21,7 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 
 */
 
-// Test if OR(... 0000 0101, ... 1010 1010) = ... 1010 1111
+// Test if operation calculate correctly for two register values
 #[test]
 pub fn test_orr_register(){
     let mut vm = create_vm_from_asm("
@@ -40,7 +40,7 @@ pub fn test_orr_register(){
     assert_vm_eq!(vm_expected, vm);
 }
 
-// Test if OR(... 0000, ... 0000) correctly sets ZERO flag
+// Test if operation set Zero flag if result is zero
 #[test]
 pub fn test_orr_flag_zero(){
     let mut vm = create_vm_from_asm("
@@ -56,7 +56,7 @@ pub fn test_orr_flag_zero(){
     assert_vm_eq!(vm_expected, vm);
 }
 
-// Test if OR(1000 ... 0000, 1000 ... 0000) correctly sets NEGATIVE flag
+// Test if operation set Negative flag if result is negative
 // ("highest" bit indicate sign in int representation, so setting it to 1 -> negative number)
 #[test]
 pub fn test_orr_flag_neg(){

--- a/tests/test_tst.rs
+++ b/tests/test_tst.rs
@@ -25,17 +25,17 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_tst_unaltered(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x000000FF
-        movs r1,            #0x0000000A
+        movs r0,            #0xFF
+        movs r1,            #0x0A
         tst r0, r1
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_00FF);
-    vm_expected.r[1] = Some(0x0000_000A);
+    vm_expected.r[0] = Some(0xFF);
+    vm_expected.r[1] = Some(0x0A);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -44,17 +44,17 @@ pub fn test_tst_unaltered(){
 #[test]
 pub fn test_tst_flag_zero(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x00000055
-        movs r1,            #0x000000AA
+        movs r0,            #0x55
+        movs r1,            #0xAA
         tst r0, r1
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x0000_0055);
-    vm_expected.r[1] = Some(0x0000_00AA);
+    vm_expected.r[0] = Some(0x55);
+    vm_expected.r[1] = Some(0xAA);
     vm_expected.z = Some(true);
     
     assert_vm_eq!(vm_expected, vm);
@@ -65,13 +65,13 @@ pub fn test_tst_flag_zero(){
 #[test]
 pub fn test_tst_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0,            #0x00000002
-        lsls r0,            #0x0000000F
-        lsls r0,            #0x0000000F
+        movs r0,            #0x08
+        lsls r0,            #0x0E
+        lsls r0,            #0x0E
         tst r0, r0
-        svc                 #0x000000FF
+        svc                 #0xFF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
+    assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     

--- a/tests/test_tst.rs
+++ b/tests/test_tst.rs
@@ -14,7 +14,6 @@ Included cases:
 - Set Negative flag if result is negative
 
 All tests also check for unexpected changes in registers and condition flags
-TODO: Add tests where untargeted values are pre-set and check if incorrectly reset?
 
 The reference for these tests is currently official documentations and a QEMU-based VM
 TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?

--- a/tests/test_tst.rs
+++ b/tests/test_tst.rs
@@ -25,17 +25,17 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_tst_unaltered(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_FF
-        movs r1, #0x00_00_00_0A
+        movs r0, #0x000000FF
+        movs r1, #0x0000000A
         tst r0, r1
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_FF);
-    vm_expected.r[1] = Some(0x00_00_00_0A);
+    vm_expected.r[0] = Some(0x0000_00FF);
+    vm_expected.r[1] = Some(0x0000_000A);
     
     assert_vm_eq!(vm_expected, vm);
 }
@@ -44,17 +44,17 @@ pub fn test_tst_unaltered(){
 #[test]
 pub fn test_tst_flag_zero(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_55
-        movs r1, #0x00_00_00_AA
+        movs r0, #0x00000055
+        movs r1, #0x000000AA
         tst r0, r1
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x00_00_00_55);
-    vm_expected.r[1] = Some(0x00_00_00_AA);
+    vm_expected.r[0] = Some(0x0000_0055);
+    vm_expected.r[1] = Some(0x0000_00AA);
     vm_expected.z = Some(true);
     
     assert_vm_eq!(vm_expected, vm);
@@ -65,17 +65,17 @@ pub fn test_tst_flag_zero(){
 #[test]
 pub fn test_tst_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00_00_00_02
-        lsls r0, #0x00_00_00_0F
-        lsls r0, #0x00_00_00_0F
+        movs r0, #0x00000002
+        lsls r0, #0x0000000F
+        lsls r0, #0x0000000F
         tst r0, r0
-        svc #0x00_00_00_FF
+        svc #0x000000FF
     ");
-    assert_eq!(vm.execute().unwrap(), 0x00_00_00_FF);
+    assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
     
-    vm_expected.r[0] = Some(0x80_00_00_00);
+    vm_expected.r[0] = Some(0x8000_0000);
     vm_expected.n = Some(true);
     
     assert_vm_eq!(vm_expected, vm);

--- a/tests/test_tst.rs
+++ b/tests/test_tst.rs
@@ -9,11 +9,11 @@ Unit test for TST operator - bitwise AND that only set flags and discard result
 
 Included cases: 
 
-- Don't alter target register (Unlike AND)
+- Don't alter target register
 - Set Zero flag if result is zero
 - Set Negative flag if result is negative
 
-All tests also check for unexpected changes in untargeted lo registers and condition flags
+All tests also check for unexpected changes in registers and condition flags
 TODO: Add tests where untargeted values are pre-set and check if incorrectly reset?
 
 The reference for these tests is currently official documentations and a QEMU-based VM
@@ -21,7 +21,7 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 
 */
 
-// Test if AND(... 0000 1111, ... 1010 1010) correctly doesn't alter target registry
+// Test if operation don't alter target register
 #[test]
 pub fn test_tst_unaltered(){
     let mut vm = create_vm_from_asm("
@@ -40,7 +40,7 @@ pub fn test_tst_unaltered(){
     assert_vm_eq!(vm_expected, vm);
 }
 
-// Test if TST(... 0101 0101, ... 1010 1010) correctly sets ZERO flag
+// Test if operation set Zero flag if result is zero
 #[test]
 pub fn test_tst_flag_zero(){
     let mut vm = create_vm_from_asm("
@@ -60,7 +60,7 @@ pub fn test_tst_flag_zero(){
     assert_vm_eq!(vm_expected, vm);
 }
 
-// Test if TST(1000 ... 0000, 1000 ... 0000) correctly sets NEGATIVE flag
+// Test if operation set Negative flag if result is negative
 // ("highest" bit indicate sign in int representation, so setting it to 1 -> negative number)
 #[test]
 pub fn test_tst_flag_neg(){

--- a/tests/test_tst.rs
+++ b/tests/test_tst.rs
@@ -25,10 +25,10 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 #[test]
 pub fn test_tst_unaltered(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x000000FF
-        movs r1, #0x0000000A
+        movs r0,            #0x000000FF
+        movs r1,            #0x0000000A
         tst r0, r1
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
@@ -44,10 +44,10 @@ pub fn test_tst_unaltered(){
 #[test]
 pub fn test_tst_flag_zero(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00000055
-        movs r1, #0x000000AA
+        movs r0,            #0x00000055
+        movs r1,            #0x000000AA
         tst r0, r1
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();
@@ -65,11 +65,11 @@ pub fn test_tst_flag_zero(){
 #[test]
 pub fn test_tst_flag_neg(){
     let mut vm = create_vm_from_asm("
-        movs r0, #0x00000002
-        lsls r0, #0x0000000F
-        lsls r0, #0x0000000F
+        movs r0,            #0x00000002
+        lsls r0,            #0x0000000F
+        lsls r0,            #0x0000000F
         tst r0, r0
-        svc #0x000000FF
+        svc                 #0x000000FF
     ");
     assert_eq!(vm.execute().unwrap(), 0x0000_00FF);
     vm.print_diagnostics();

--- a/tests/test_tst.rs
+++ b/tests/test_tst.rs
@@ -7,7 +7,7 @@ use common::*;
 
 Unit test for TST operator - bitwise AND that only set flags and discard result
 
-Included cases: 
+Included cases:
 
 - Don't alter target register
 - Set Zero flag if result is zero
@@ -23,60 +23,66 @@ TODO: Test against a hardware Cortex-M0 to make sure it's actually up to spec?
 
 // Test if operation don't alter target register
 #[test]
-pub fn test_tst_unaltered(){
-    let mut vm = create_vm_from_asm("
+pub fn test_tst_unaltered() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0xFF
         movs r1,            #0x0A
         tst r0, r1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0xFF);
     vm_expected.r[1] = Some(0x0A);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 // Test if operation set Zero flag if result is zero
 #[test]
-pub fn test_tst_flag_zero(){
-    let mut vm = create_vm_from_asm("
+pub fn test_tst_flag_zero() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x55
         movs r1,            #0xAA
         tst r0, r1
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0x55);
     vm_expected.r[1] = Some(0xAA);
     vm_expected.z = Some(true);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }
 
 // Test if operation set Negative flag if result is negative
 // ("highest" bit indicate sign in int representation, so setting it to 1 -> negative number)
 #[test]
-pub fn test_tst_flag_neg(){
-    let mut vm = create_vm_from_asm("
+pub fn test_tst_flag_neg() {
+    let mut vm = create_vm_from_asm(
+        "
         movs r0,            #0x08
         lsls r0,            #0x0E
         lsls r0,            #0x0E
         tst r0, r0
         svc                 #0xFF
-    ");
+    ",
+    );
     assert_eq!(vm.execute().unwrap(), 0xFF);
     vm.print_diagnostics();
     let mut vm_expected: VMState = Default::default();
-    
+
     vm_expected.r[0] = Some(0x8000_0000);
     vm_expected.n = Some(true);
-    
+
     assert_vm_eq!(vm_expected, vm);
 }


### PR DESCRIPTION
Turns out the 00_00_00_00 hex format isn't actually supported by the compiler, it just happened to work for some reason. 