### PR TITLE
Fix comparison bug

### DIFF
--- a/src/narmvm.rs
+++ b/src/narmvm.rs
@@ -261,7 +261,7 @@ impl NarmVM{
             match op{
                 //0100_0001_01xx_xyyy ADC reg T1 flags
                 0b0100_0001_0100_0000 => {
-                    self.sreg[reg2] = self.op_add(self.sreg[reg1], self.sreg[reg2], self.cpsr.c, true);
+                    self.sreg[reg2] = self.op_add(self.sreg[reg2], self.sreg[reg1], self.cpsr.c, true);
                     return Ok(0);
                 },
                 //0100_0000_00xx_xyyy AND reg T1 flags

--- a/src/narmvm.rs
+++ b/src/narmvm.rs
@@ -882,12 +882,14 @@ impl NarmVM{
         self.cpsr.z = result == 0;
     }
     fn op_add(&mut self, operand1: u32, operand2: u32, carry_in: bool, set_flags: bool) -> u32{
-        let prelim_sum = if carry_in{
-            operand1.wrapping_add(1)
-        }else{
-            operand1
-        };
-        let (result, carry) = prelim_sum.overflowing_add(operand2);
+        let (prelim_sum, precarry) = operand1.overflowing_add(carry_in as u32);
+        let (result, mut carry) = prelim_sum.overflowing_add(operand2);
+        
+        // It's impossible for both carry and precarry to be set here, because: 
+        // 1. Precarry set means that prelim_sum = 0 (Because +1 only ever overflows u32::MAX)
+        // 2. There exists no u32 such that adding it to the u32 0 would overflow it (0 + u32::MAX = u32::MAX, no overflow)
+        carry = carry | precarry;
+
         if set_flags{
             let (_, overflow) = (prelim_sum as i32).overflowing_add(operand2 as i32);
             self.cpsr.v = overflow;

--- a/src/narmvm.rs
+++ b/src/narmvm.rs
@@ -350,7 +350,7 @@ impl NarmVM{
                 0b0100_0011_0100_0000 => {
                     let (result, _) = (valuen as u32).overflowing_mul(valuem as u32);
                     self.sreg[reg2] = result;
-                    self.set_result_flags(self.sreg[reg2]);
+                    self.set_result_flags(result);
                     return Ok(0);
                 },
                 //0100_0011_11xx_xyyy MVNS T1 flags

--- a/src/narmvm.rs
+++ b/src/narmvm.rs
@@ -881,6 +881,7 @@ impl NarmVM{
         self.cpsr.n = result.get_bit(31);
         self.cpsr.z = result == 0;
     }
+    
     fn op_add(&mut self, operand1: u32, operand2: u32, carry_in: bool, set_flags: bool) -> u32{
         let (prelim_sum, precarry) = operand1.overflowing_add(carry_in as u32);
         let (result, mut carry) = prelim_sum.overflowing_add(operand2);
@@ -891,7 +892,11 @@ impl NarmVM{
         carry = carry | precarry;
 
         if set_flags{
-            let (_, overflow) = (prelim_sum as i32).overflowing_add(operand2 as i32);
+            let (_, preoverflow) = (operand1 as i32).overflowing_add(carry_in as i32);
+            let (_, mut overflow) = (prelim_sum as i32).overflowing_add(operand2 as i32);
+            
+            // Both these flags can't ever both be set for analogous reasons as for carry
+            overflow = overflow | preoverflow;
             self.cpsr.v = overflow;
             self.cpsr.c = carry;
             self.cpsr.n = result.get_bit(31);

--- a/tests/test_add.rs
+++ b/tests/test_add.rs
@@ -351,12 +351,13 @@ pub fn test_add_flag_carry() {
     // 3: ADD <Rdn>, <Rm> T2 - Not applicable
 
     // 4: ADCS <Rdn>, <Rm> T1
+    vm_states[4].c = Some(true); // Also test proper behavior if carry causes overflow
     create_vm!(
         arrays = (vms, vm_states),
         op_id = 4,
         asm_literal_add_svc = "adcs  r0, r2"
     );
-    vm_states[4].r[0] = Some(0x05);
+    vm_states[4].r[0] = Some(0x06); // +1 because of carry
 
     // 5: CMN <Rn>, <Rm> T1
     create_vm!(
@@ -425,13 +426,13 @@ pub fn test_add_flag_v() {
     // 3: ADD <Rdn>, <Rm> T2 - Not applicable
 
     // 4: ADCS <Rdn>, <Rm> T1
-    vm_states[4].r[0] = Some(0x7FFF_FFFE); // Since carry is set we have to do -1 here to get same result!
+    vm_states[4].r[0] = Some(0x7FFF_FFFF); // Also test proper behavior if carry causes overflow
     create_vm!(
         arrays = (vms, vm_states),
         op_id = 4,
         asm_literal_add_svc = "adcs  r0, r2"
     );
-    vm_states[4].r[0] = Some(0x8000_0005);
+    vm_states[4].r[0] = Some(0x8000_0006); // +1 because of carry
 
     // 5: CMN <Rn>, <Rm> T1
     create_vm!(

--- a/tests/test_add.rs
+++ b/tests/test_add.rs
@@ -425,12 +425,13 @@ pub fn test_add_flag_v() {
     // 3: ADD <Rdn>, <Rm> T2 - Not applicable
 
     // 4: ADCS <Rdn>, <Rm> T1
+    vm_states[4].r[0] = Some(0x7FFF_FFFE); // Since carry is set we have to do -1 here to get same result!
     create_vm!(
         arrays = (vms, vm_states),
         op_id = 4,
         asm_literal_add_svc = "adcs  r0, r2"
-    ); // +1 (carry)
-    vm_states[4].r[0] = Some(0x8000_0006);
+    );
+    vm_states[4].r[0] = Some(0x8000_0005);
 
     // 5: CMN <Rn>, <Rm> T1
     create_vm!(

--- a/tests/test_sub.rs
+++ b/tests/test_sub.rs
@@ -388,6 +388,8 @@ pub fn test_sub_flag_carry() {
     );
 
     // 3: SBCS <Rdn>, <Rm> T1
+    vm_states[3].r[0] = Some(0x00); // Also test proper behavior if carry causes overflow
+    vm_states[3].c = Some(false);
     create_vm!(
         arrays = (vms, vm_states),
         op_id = 3,
@@ -417,6 +419,7 @@ pub fn test_sub_flag_carry() {
 
     // Common expected post-execution state
     set_for_all!(vm_states[ops_to_test].r[0] = Some(0xFFFF_FFFF)); // = -1
+    vm_states[3].r[0] = Some(0xFFFF_FF00);
     vm_states[5].r[0] = None; // Op discards result anyway
     vm_states[6].r[0] = None; // Op discards result anyway
 
@@ -476,6 +479,7 @@ pub fn test_sub_flag_v() {
     );
 
     // 3: SBCS <Rdn>, <Rm> T1
+    vm_states[3].r[0] = Some(0x8000_0000); // Also test proper behavior if carry causes overflow
     create_vm!(
         arrays = (vms, vm_states),
         op_id = 3,
@@ -502,6 +506,7 @@ pub fn test_sub_flag_v() {
 
     // Common expected post-execution state
     set_for_all!(vm_states[ops_to_test].r[0] = Some(0x7FFF_FFFF));
+    vm_states[3].r[0] = Some(0x7FFF_FF01);
     vm_states[5].r[0] = None; // Op discards result anyway
     vm_states[6].r[0] = None; // Op discards result anyway
 

--- a/tests/test_sub.rs
+++ b/tests/test_sub.rs
@@ -336,8 +336,6 @@ pub fn test_sub_flag_zero() {
     set_for_all!(vm_states[ops_to_test].c = Some(true)); // Set *unless* there is unsigned overflow
     set_for_all!(vm_states[ops_to_test].v = Some(false));
 
-    vm_states[4].c = Some(false); // Ugly, but here we are. Reverse subtract with its 0 - (>0) will always "set" carry
-
     run_test!(arrays = (vms, vm_states), op_ids = ops_to_test);
 }
 
@@ -504,7 +502,6 @@ pub fn test_sub_flag_v() {
 
     // Common expected post-execution state
     set_for_all!(vm_states[ops_to_test].r[0] = Some(0x7FFF_FFFF));
-    vm_states[4].r[0] = Some(0x8FFF_FFFA);
     vm_states[5].r[0] = None; // Op discards result anyway
     vm_states[6].r[0] = None; // Op discards result anyway
 


### PR DESCRIPTION
An incorrect carry behavior in edge cases was causing e.g. all Rust PartialEq on reference types to misbehave. 

Big kudos to Earlz who actually found the fix!