### PR TITLE
Fix incorrect handling of direct PC writes

### DIFF
--- a/src/narmvm.rs
+++ b/src/narmvm.rs
@@ -934,8 +934,8 @@ impl NarmVM{
         if reg == 13{
             final_value = value.align4(); //special handling of r13/LR
         } else if reg == 15{
-            //special handling for r15/PC
-            self.pc = value.align4();
+            // Direct PC writes (no interworking) should set lowest bit to current mode (1/thumbs for this VM)
+            self.pc = value | 1;
             return;
         }
         if reg < 8{


### PR DESCRIPTION
Caused a crash when trying to use neutron-star print macro with formatting, which apparently used ADD T2 to set the PC.